### PR TITLE
Mlewis/add http mirror installation

### DIFF
--- a/https_mirror_install.sh
+++ b/https_mirror_install.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+set -o errexit
+
+usage() {
+  this=$1
+  cat <<EOF
+
+$this: download binaries for sopstool and sops from the https mirror
+
+Usage: $this [bindir]
+  [bindir] sets bindir or installation directory, Defaults to ./bin
+
+  SOPS_VERSION overrides the sops version tag downloaded
+  SOPSTOOL_VERSION overrides the sopstool version tag downloaded
+
+Inspired by godownloader
+ https://github.com/goreleaser/godownloader
+
+EOF
+  exit 2
+}
+
+cd $(mktemp -d)
+curl -o sopstool.tar.gz https://oss-pkg.ibotta.com/sopstool/sopstool_linux.tar.gz
+tar -xvzf sopstool.tar.gz
+curl -o sops.tar.gz https://oss-pkg.ibotta.com/sops/sops_linux.tar.gz
+tar -xvzf sops.tar.gz
+mv sops /bin
+mv sopstool /bin
+rm -r $(pwd)

--- a/https_mirror_install.sh
+++ b/https_mirror_install.sh
@@ -1,25 +1,4 @@
 #!/bin/sh
-set -e
-set -o errexit
-
-usage() {
-  this=$1
-  cat <<EOF
-
-$this: download binaries for sopstool and sops from the https mirror
-
-Usage: $this [bindir]
-  [bindir] sets bindir or installation directory, Defaults to ./bin
-
-  SOPS_VERSION overrides the sops version tag downloaded
-  SOPSTOOL_VERSION overrides the sopstool version tag downloaded
-
-Inspired by godownloader
- https://github.com/goreleaser/godownloader
-
-EOF
-  exit 2
-}
 
 cd $(mktemp -d)
 curl -o sopstool.tar.gz https://oss-pkg.ibotta.com/sopstool/sopstool_linux.tar.gz


### PR DESCRIPTION
Story/Issue Link
-----

[Issue 27: Github rate limiting question](https://github.com/Ibotta/sopstool/issues/27)

Background
-----

The purpose of this PR is to add a new installation option for when a user is having rate limiting issues during installation. This script mirrors the process I wrote to install sopstool on a cluster that was experiencing this issue. 


Additional Requests to Reviewers
-----

Would like some suggestions on how to generalize this installer. Right now the `bin` path is hard coded. 

Assuming this is good, I will update the Readme.

/cc
-----

@blimmer 
