### PR TITLE
Ensure plaintext files get cleaned if entrypoint fails.

### DIFF
--- a/cmd/entrypoint.go
+++ b/cmd/entrypoint.go
@@ -32,6 +32,8 @@ func init() {
 }
 
 // EntrypointCommand the command for the add command
+// Note the named return parameter, it is used to tack on errors during
+// the deferred encrypted file cleanup.
 func EntrypointCommand(cmd *cobra.Command, args []string) (rerr error) {
 	initConfig()
 
@@ -40,9 +42,10 @@ func EntrypointCommand(cmd *cobra.Command, args []string) (rerr error) {
 		return err
 	}
 	defer func() {
-		err := CleanCommand(cmd, filesToDecrypt)
-		if err != nil {
-			rerr = fmt.Errorf("Encrypted file cleanup error:\n%s\n%s", err, rerr)
+		cleanupErr := CleanCommand(cmd, filesToDecrypt)
+		if cleanupErr != nil {
+			// Using the named return to stack errors.
+			rerr = fmt.Errorf("Encrypted file cleanup error:\n%s\n%s", cleanupErr, rerr)
 		}
 	}()
 


### PR DESCRIPTION
Story/Issue Link
-----

Fixes: #29 -- `sopstool entrypoint` fails to delete cleartext files on non-zero exit codes

Versioning
-----

Next version should be a patch release as no functionality is changing.

Additional Requests to Reviewers
-----

Add any additional high-level requests for reviewers.

Tasks
-----

* [ ] Specs written
* [ x ] Manual testing

/cc
-----

@onyxraven @ibottamike 