### PR TITLE
docs: fix bash parameter syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl https://raw.githubusercontent.com/Ibotta/sopstool/master/install.sh | bash
 Example with overrides:
 
 ```sh
-curl https://raw.githubusercontent.com/Ibotta/sopstool/master/install.sh | SOPS_VERSION=3.0.0 SOPSTOOL_VERSION=0.3.0 bash /usr/local/bin
+curl https://raw.githubusercontent.com/Ibotta/sopstool/master/install.sh | SOPS_VERSION=3.0.0 SOPSTOOL_VERSION=0.3.0 bash -s /usr/local/bin
 ```
 
 ### Docker


### PR DESCRIPTION
Background
-----

The syntax used in the example of passing a custom location for sopstool is incorrect. It displays this error message:

```
/usr/local/bin: /usr/local/bin: is a directory
```

If you use `-s`, it works as expected.

Versioning
-----

N/A. Docs only.
