### PR TITLE
Add updatekeys command

### DIFF
--- a/cmd/updatekeys.go
+++ b/cmd/updatekeys.go
@@ -1,0 +1,48 @@
+// Copyright © 2017 Ibotta
+
+package cmd
+
+import (
+	"github.com/Ibotta/sopstool/fileutil"
+	"github.com/spf13/cobra"
+)
+
+// updatekeysCmd represents the updatekeysCmd command
+var updatekeysCmd = &cobra.Command{
+	Use:   "updatekeys [files ...]",
+	Short: "update recipients keys",
+	Long:  "update recipients keys",
+	RunE:  UpdateKeysCommand,
+}
+
+var nonInteractiveMode bool
+
+func init() {
+	RootCmd.AddCommand(updatekeysCmd)
+	updatekeysCmd.Flags().BoolVar(&nonInteractiveMode, "non-interactive", false, "pre-approve all changes and run non-interactively")
+}
+
+// UpdateKeysCommand updates recipients keys
+func UpdateKeysCommand(cmd *cobra.Command, args []string) error {
+	initConfig()
+	var extraArgs []string
+
+	filesToUpdate, err := fileutil.SomeOrAllFiles(args, sopsConfig.EncryptedFiles)
+	if err != nil {
+		return err
+	}
+
+	if nonInteractiveMode {
+		extraArgs = append(extraArgs, "--yes")
+	}
+
+	//Update recipients keys on files
+	for _, f := range filesToUpdate {
+		err := encrypter.UpdateKeysFile(f, extraArgs)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/filecrypt/interface.go
+++ b/filecrypt/interface.go
@@ -8,4 +8,5 @@ type FileCrypt interface {
 	RemoveCryptFile(fn string) error
 	RotateFile(fn string) error
 	EditFile(fn string) error
+	UpdateKeysFile(fn string, extraArgs []string) error
 }

--- a/filecrypt/sops.go
+++ b/filecrypt/sops.go
@@ -63,3 +63,10 @@ func (sops sopsCrypt) EditFile(fn string) error {
 
 	return sops.execWrap.RunCommandDirect([]string{"sops", cryptfile})
 }
+
+// UpdateKeysFile update the keys of a SOPS file
+func (sops sopsCrypt) UpdateKeysFile(fn string, extraArgs []string) error {
+	cryptfile := fileutil.NormalizeToSopsFile(fn)
+	cmd := append([]string{"sops", "updatekeys", cryptfile}, extraArgs...)
+	return sops.execWrap.RunCommandDirect(cmd)
+}

--- a/filecrypt/sops_test.go
+++ b/filecrypt/sops_test.go
@@ -124,6 +124,25 @@ func TestRemoveCryptFile(t *testing.T) {
 	})
 }
 
+func TestUpdateKeysFile(t *testing.T) {
+	origEw := sops.execWrap
+	t.Run("run updatekeys", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mock := mock_oswrap.NewMockExecWrap(ctrl)
+
+		mock.EXPECT().RunCommandDirect(gomock.Eq([]string{"sops", "updatekeys", "myfile.sops.yaml"})).Return(nil)
+		sops.execWrap = mock
+
+		err := sops.UpdateKeysFile("myfile.yaml", []string{})
+		if err != nil {
+			t.Errorf("TestUpdateKeysFile() unexpected error %v", err)
+		}
+
+		sops.execWrap = origEw
+	})
+}
+
 func TestRotateFile(t *testing.T) {
 	origEw := sops.execWrap
 	t.Run("run rotate", func(t *testing.T) {


### PR DESCRIPTION
Story/Issue Link
-----

Fixes #23 -- shortcut to update the KMS keys and rotate all files 

Background
-----
I started using sopstool and I noticed that the updatekeys command is missing. So I decided to implement it on my own. 
Firstly I was thinking about combining it with rotate command but I found that sops maintainers recommend keeping these commands separated. https://github.com/mozilla/sops/issues/365#issuecomment-401015174

It's my first PR in this project so let me know if i did something wrong :)


<!--
Add background information that will be helpful to reviewers:

* Why are we making this change?
* How you arrived at this solution
* High level overview of when / how this code is executed
* Link to related Stories/Issues/PRs
-->

Versioning
-----
v1.1.0
<!--
Indicate the intended next version, and any special considerations

* Review the [Contributing Guide on Versioning](CONTRIBUTING.md#versioning)
* Ensure you are ready to increment an appropriate part of the version to release
-->

Additional Requests to Reviewers
-----

<!-- Add any additional high-level requests for reviewers. -->

Tasks
-----

* [ ] Specs written
* [x] Manual testing
