### PR TITLE
Add proper .sops extension for file without extension

### DIFF
--- a/fileutil/fileutil.go
+++ b/fileutil/fileutil.go
@@ -31,7 +31,12 @@ func NormalizeToSopsFile(fn string) string {
 	}
 
 	ext := path.Ext(fn)
-	fn = strings.Replace(fn, ext, sopsCryptedFileSegment+ext, 1)
+
+	if len(ext) > 0 {
+		fn = strings.Replace(fn, ext, sopsCryptedFileSegment+ext, 1)
+	} else {
+		fn = fn + sopsCryptedFileSegment
+	}
 
 	return fn
 }

--- a/fileutil/fileutil_test.go
+++ b/fileutil/fileutil_test.go
@@ -21,6 +21,7 @@ func TestNormalizeToPlaintextFile(t *testing.T) {
 		{name: "Without the segment", args: args{fn: "filename.yaml"}, want: "filename.yaml"},
 		{name: "With the segment twice", args: args{fn: "filename.sops.something.sops.yaml"}, want: "filename.sops.something.yaml"},
 		{name: "With the segment last", args: args{fn: "something.bin.sops"}, want: "something.bin"},
+		{name: "With no extension", args: args{fn: "something.sops"}, want: "something"},
 	}
 
 	for _, tt := range tests {
@@ -102,6 +103,22 @@ func TestListIndexOf(t *testing.T) {
 			},
 			want: 0,
 		},
+		{
+			name: "no ext",
+			args: args{
+				files: []string{"filename.ext", "filename2.ext", "fnhere"},
+				fn:    "fnhere",
+			},
+			want: 2,
+		},
+		{
+			name: "no ext normalized",
+			args: args{
+				files: []string{"filename.ext", "filename2.ext", "fnhere"},
+				fn:    "fnhere.sops",
+			},
+			want: 2,
+		},
 	}
 
 	for _, tt := range tests {
@@ -149,6 +166,24 @@ func TestSomeOrAllFiles(t *testing.T) {
 				encFiles: []string{"filename.ext", "filename2.ext", "filename3.ext"},
 			},
 			want:    []string{"filename.ext"},
+			wantErr: false,
+		},
+		{
+			name: "one file no ext",
+			args: args{
+				args:     []string{"filename"},
+				encFiles: []string{"filename", "filename2.ext", "filename3.ext"},
+			},
+			want:    []string{"filename"},
+			wantErr: false,
+		},
+		{
+			name: "one file normalized no ext",
+			args: args{
+				args:     []string{"filename.sops"},
+				encFiles: []string{"filename", "filename2.ext", "filename3.ext"},
+			},
+			want:    []string{"filename"},
 			wantErr: false,
 		},
 		{

--- a/fileutil/fileutil_test.go
+++ b/fileutil/fileutil_test.go
@@ -47,6 +47,7 @@ func TestNormalizeToSopsFile(t *testing.T) {
 		{name: "With the segment twice", args: args{fn: "filename.sops.something.sops.yaml"}, want: "filename.sops.something.sops.yaml"},
 		{name: "With the segment in the wrong place", args: args{fn: "filename.sops.something.yaml"}, want: "filename.sops.something.sops.yaml"},
 		{name: "Ends with segment", args: args{fn: "filename.yaml.sops"}, want: "filename.yaml.sops"},
+		{name: "Without the extension", args: args{fn: "filename_no_ext"}, want: "filename_no_ext.sops"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Story/Issue Link
-----

Fixes #11 

Background
-----
Currently, if you add a file without an extension then ".sops" extension is added as a prefix. It looks strange and disallows adding a file with a local path for example ./file_no_ext.
I added a simple conditional which handle this case :)

<!--
Add background information that will be helpful to reviewers:

* Why are we making this change?
* How you arrived at this solution
* High level overview of when / how this code is executed
* Link to related Stories/Issues/PRs
-->

Versioning
-----
Patch version
<!--
Indicate the intended next version, and any special considerations

* Review the [Contributing Guide on Versioning](CONTRIBUTING.md#versioning)
* Ensure you are ready to increment an appropriate part of the version to release
-->

Additional Requests to Reviewers
-----

<!-- Add any additional high-level requests for reviewers. -->

Tasks
-----

* [ ] Specs written
* [x] Manual testing


