### PR TITLE
bump to go 1.20 and deps

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.50.0
+          version: "v1.50.0"
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: "1.20"
       - uses: actions/checkout@v3
@@ -19,7 +19,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: "v1.50.0"
+          version: "v1.52.2"
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Fetch all tags
@@ -32,12 +32,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - name: mod download
         run: go mod download && go build
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: mod download
         run: go mod download && go build
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20
       - name: mod download
         run: go mod download && go build
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Fetch all tags
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - name: mod download
         run: go mod download && go build
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.19
+golang 1.20

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 // AddCommand the command for the add command
-func AddCommand(cmd *cobra.Command, args []string) error {
+func AddCommand(_ *cobra.Command, args []string) error {
 	initConfig()
 
 	for _, fileArg := range args {

--- a/cmd/cat.go
+++ b/cmd/cat.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 // CatCommand prints a file to stdout
-func CatCommand(cmd *cobra.Command, args []string) error {
+func CatCommand(_ *cobra.Command, args []string) error {
 	initConfig()
 
 	for _, fileArg := range args {

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 // CleanCommand cleans up files
-func CleanCommand(cmd *cobra.Command, args []string) error {
+func CleanCommand(_ *cobra.Command, args []string) error {
 	initConfig()
 
 	filesToClean, err := fileutil.SomeOrAllFiles(args, sopsConfig.EncryptedFiles)

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 // CompletionCommand the command for the add command
-func CompletionCommand(cmd *cobra.Command, args []string) error {
+func CompletionCommand(_ *cobra.Command, _ []string) error {
 	switch shellType {
 	case "bash":
 		return RootCmd.GenBashCompletion(os.Stdout)

--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 // DecryptCommand decrypts files
-func DecryptCommand(cmd *cobra.Command, args []string) error {
+func DecryptCommand(_ *cobra.Command, args []string) error {
 	initConfig()
 
 	filesToDecrypt, err := fileutil.SomeOrAllFiles(args, sopsConfig.EncryptedFiles)

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 // DocsCommand the command for the add command
-func DocsCommand(cmd *cobra.Command, args []string) error {
+func DocsCommand(_ *cobra.Command, _ []string) error {
 	err := doc.GenMarkdownTree(RootCmd, "./docs")
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 // EditCommand edit a file
-func EditCommand(cmd *cobra.Command, args []string) error {
+func EditCommand(_ *cobra.Command, args []string) error {
 	initConfig()
 
 	fn := fileutil.NormalizeToPlaintextFile(args[0])

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 // ListCommand the command for the list command
-func ListCommand(cmd *cobra.Command, args []string) {
+func ListCommand(_ *cobra.Command, _ []string) {
 	initConfig()
 
 	for _, fn := range sopsConfig.EncryptedFiles {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 // RemoveCommand the command for the add command
-func RemoveCommand(cmd *cobra.Command, args []string) error {
+func RemoveCommand(_ *cobra.Command, args []string) error {
 	initConfig()
 
 	for _, fileArg := range args {

--- a/cmd/rotate.go
+++ b/cmd/rotate.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 // RotateCommand Rotates up files
-func RotateCommand(cmd *cobra.Command, args []string) error {
+func RotateCommand(_ *cobra.Command, args []string) error {
 	initConfig()
 
 	filesToRotate, err := fileutil.SomeOrAllFiles(args, sopsConfig.EncryptedFiles)

--- a/cmd/updatekeys.go
+++ b/cmd/updatekeys.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 // UpdateKeysCommand updates recipients keys
-func UpdateKeysCommand(cmd *cobra.Command, args []string) error {
+func UpdateKeysCommand(_ *cobra.Command, args []string) error {
 	initConfig()
 	var extraArgs []string
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,7 +25,7 @@ func init() {
 }
 
 // VersionCommand prints the version
-func VersionCommand(cmd *cobra.Command, args []string) {
+func VersionCommand(_ *cobra.Command, _ []string) {
 	if shortString {
 		fmt.Println(BuildVersion)
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/golang/mock v1.6.0
 	github.com/mozilla-services/yaml v0.0.0-20201007153854-c369669a6625
-	github.com/spf13/cobra v1.6.1
+	github.com/spf13/cobra v1.7.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,15 +2,14 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHH
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
-github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/mozilla-services/yaml v0.0.0-20201007153854-c369669a6625 h1:5IeGQzguDQ+EsTR5HE7tMYkZe09mqQ9cDypdKQEB5Kg=
 github.com/mozilla-services/yaml v0.0.0-20201007153854-c369669a6625/go.mod h1:Is/Ucts/yU/mWyGR8yELRoO46mejouKsJfQLAIfTR18=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
-github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=


### PR DESCRIPTION
Background
-----

bumping to go 1.20

- updated cobra
- updated linter (and fixed lints)

Versioning
-----

patch

