### PR TITLE
docs: fix typos and copy-paste errors in comments and strings

### DIFF
--- a/cmd/entrypoint.go
+++ b/cmd/entrypoint.go
@@ -31,7 +31,7 @@ func init() {
 	entrypointCmd.Flags().BoolVar(&allowFail, "allow-fail", false, "Do not fail if not all files can be decrypted")
 }
 
-// EntrypointCommand the command for the add command
+// EntrypointCommand the command for the entrypoint command
 // Note the named return parameter, it is used to tack on errors during
 // the deferred encrypted file cleanup.
 func EntrypointCommand(cmd *cobra.Command, args []string) (rerr error) {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -16,7 +16,7 @@ var removeCmd = &cobra.Command{
 	Use:     "remove [files ...]",
 	Short:   "remove file from the encryption list",
 	Args:    cobra.MinimumNArgs(1),
-	Long:    `Remove files to the list of files managed by sopstool`,
+	Long:    `Remove files from the list of files managed by sopstool`,
 	RunE:    RemoveCommand,
 }
 
@@ -28,7 +28,7 @@ func init() {
 	removeCmd.Flags().BoolVarP(&deleteFiles, "delete", "d", false, "Also delete the file")
 }
 
-// RemoveCommand the command for the add command
+// RemoveCommand the command for the remove command
 func RemoveCommand(_ *cobra.Command, args []string) error {
 	initConfig()
 

--- a/scm/git.go
+++ b/scm/git.go
@@ -34,7 +34,7 @@ func (g Git) RemoveFileFromIgnored(fn string) error {
 	}
 
 	if !exists {
-		fmt.Println("file not exists in .gitignore file. Skipping.")
+		fmt.Println("file does not exist in .gitignore file. Skipping.")
 		return nil
 	}
 	return removeLineFromFile(fn, g.IgnoreFilePath)
@@ -134,7 +134,7 @@ func removeLineFromFile(line string, filename string) error {
 	}
 	defer tempFile.Close()
 
-	//Write file conent omitting specific line to tempFile
+	//Write file content omitting specific line to tempFile
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		if scanner.Text() != line {


### PR DESCRIPTION
## Summary

Fix 5 issues across 3 files:

- `scm/git.go`: fix grammar in print statement (`file not exists` → `file does not exist`), fix typo in comment (`conent` → `content`)
- `cmd/remove.go`: fix preposition (`Remove files to` → `Remove files from`), fix copy-paste error in comment (`the add command` → `the remove command`)
- `cmd/entrypoint.go`: fix copy-paste error in comment (`the add command` → `the entrypoint command`)

No functional changes — comments and user-facing strings only.